### PR TITLE
Use relative paths when running ESLint

### DIFF
--- a/µESLint.novaextension/Scripts/core/eslint.js
+++ b/µESLint.novaextension/Scripts/core/eslint.js
@@ -107,7 +107,7 @@ class ESLint {
       console.warn(error)
     }
 
-    const cwd = nova.workspace.path; // plugins may fail when this is omitted
+    const cwd = nova.workspace.path // plugins may fail when this is omitted
     const opts = { args: args, cwd: cwd, shell: false }
     const { code, stderr, stdout } = await runAsync(this.binary, opts, source)
     if (code > 1) {

--- a/µESLint.novaextension/Scripts/core/eslint.js
+++ b/µESLint.novaextension/Scripts/core/eslint.js
@@ -95,7 +95,8 @@ class ESLint {
    * @param {string} path - The file path the source belongs to.
    */
   async lint (source, path) {
-    const args = ['-f', 'json', '--stdin', '--stdin-filename', path]
+    const relativePath = nova.workspace.relativizePath(path)
+    const args = ['-f', 'json', '--stdin', '--stdin-filename', relativePath]
 
     // Use caching if we can get hold of the temp directory.
     // Failure to do so just slightly degrades performance,
@@ -106,7 +107,7 @@ class ESLint {
       console.warn(error)
     }
 
-    const cwd = nova.path.dirname(path) // plugins may fail when this is omitted
+    const cwd = nova.workspace.path; // plugins may fail when this is omitted
     const opts = { args: args, cwd: cwd, shell: false }
     const { code, stderr, stdout } = await runAsync(this.binary, opts, source)
     if (code > 1) {


### PR DESCRIPTION
The ESLint TypeScript plugins need to find `tsconfig.json` which is in the root of the project workspace. It depends on being started in the project root directory, and being passed the relative path to the file being linted.

Otherwise you get the error `Parsing error: Cannot read file 'tsconfig.json'.`

This PR updates the `ESLint.lint` method. It will:

* set `cwd` to the workspace root instead of the file’s directory
* set `--stdin-filename` to the file’s path relative to the workspace root

Unfortunately I don’t know if this will break things for other users. I don’t think so but I am not an ESLint expert. It does fix the problem with my TypeScript projects, and it still is able to lint the `microESLint.nova` project which is not TypeScript.